### PR TITLE
fix unmount devices when scrpit chroot

### DIFF
--- a/alpine-make-rootfs
+++ b/alpine-make-rootfs
@@ -188,6 +188,14 @@ prepare_chroot() {
 	echo "$RESOLVCONF_MARK" >> "$dest"/etc/resolv.conf
 }
 
+umount_chroot() {
+	local dest="$1"
+
+	umount "$dest"/proc
+	umount "$dest"/dev
+	umount "$dest"/sys
+}
+
 # Sets up timezone $1 in Alpine rootfs.
 setup_timezone() {
 	local timezone="$1"
@@ -392,7 +400,7 @@ if [ "$SCRIPT" ]; then
 		chroot "$rootfs" \
 			sh -c "cd /mnt && ./$script_name \"\$@\"" -- "$@" >&2 \
 			|| die 'Script failed'
-		umount_recursively "$rootfs"
+		umount_chroot "$rootfs"
 	fi
 fi
 


### PR DESCRIPTION
When the chroot destination is a folder and this folder is already a
mounted partition (ie: a loop mount of an fs file to create a rootfs),
if the install script is run chrooted (--script-chroot), than at the end
of the execution of the install script we try to unmount recursively
everything that is mounted in the destination folder AND the
destination, which will cause the end of this script to fail.

The solution I am proposing is to create another bash function to
unmount only required devices for the chroot (/proc, /dev and /sys).