### PR TITLE
Fix breakage of the apk cache directory

### DIFF
--- a/alpine-make-rootfs
+++ b/alpine-make-rootfs
@@ -405,11 +405,14 @@ _apk del --root "$rootfs" --purge "$VIRTUAL_PKG" >&2
 if grep -qw "$RESOLVCONF_MARK" "$rootfs"/etc/resolv.conf 2>/dev/null; then
 	rm "$rootfs"/etc/resolv.conf
 fi
-rm -Rf "$rootfs"/var/cache/apk
+
 rm -Rf "$rootfs"/dev/*
 
-[ -f "$rootfs"/sbin/apk ] \
-	|| rm -Rf "$rootfs"/etc/apk "$rootfs"/lib/apk
+if [ -f "$rootfs"/sbin/apk ]; then
+	rm -Rf "$rootfs"/var/cache/apk/*
+else
+	rm -Rf "$rootfs"/etc/apk "$rootfs"/lib/apk "$rootfs"/var/cache/apk
+fi
 
 for dir in $FUTILE_DIRS; do
 	rmdir -p "$rootfs$dir" 2>/dev/null || true


### PR DESCRIPTION
If the package 'apk-tools' is included in the rootfs,
we want to leave the '/var/cache/apk' directory empty,
 and in place. Without this directory apk will fail
with errors about Bad file descriptor when trying to fetch indexes