### PR TITLE
Call shell by absolute path in chroot

### DIFF
--- a/alpine-make-rootfs
+++ b/alpine-make-rootfs
@@ -429,7 +429,7 @@ if [ "$SCRIPT" ]; then
 		prepare_chroot "$rootfs"
 		mount_bind "${SCRIPT%/*}" "$rootfs"/mnt
 		chroot "$rootfs" \
-			sh -c "cd /mnt && ./$script_name \"\$@\"" -- "$@" >&2 \
+			/bin/sh -c "cd /mnt && ./$script_name \"\$@\"" -- "$@" >&2 \
 			|| die 'Script failed'
 		umount_recursively "$rootfs"
 	fi


### PR DESCRIPTION
When using the `--script-chroot` option, `chroot` is called with just `sh` (relative path), relying on the host environment's `$PATH` to find the executable. At least on Arch Linux, this does not work, as Arch Linux by default does not have `/bin` in the `PATH` (`/bin` is just a symlink to `/usr/bin`).

Since the chroot system was just built and it is know to contain `/bin/sh`, I think it makes sense to just call it explicitly here.