### PR TITLE
Disable root log in

### DIFF
--- a/alpine-make-rootfs
+++ b/alpine-make-rootfs
@@ -399,6 +399,9 @@ if ! [ -f "$rootfs"/etc/alpine-release ]; then
 	fi
 fi
 
+# Disable root log in without password.
+sed -i 's/^root::/root:*:/' "$rootfs"/etc/shadow
+
 [ -e "$rootfs"/var/run ] || ln -s /run "$rootfs"/var/run
 
 #-----------------------------------------------------------------------


### PR DESCRIPTION
Set second field in /etc/shadow to * so the root user will not be able to use a password to log in