### PR TITLE
install ALPINE_BASE_PKGS first if requested

### DIFF
--- a/alpine-make-rootfs
+++ b/alpine-make-rootfs
@@ -319,11 +319,8 @@ case "$ROOTFS_DEST" in
 esac
 [ -z "$FS_SKEL_DIR" ] || host_pkgs="$host_pkgs rsync"
 
-rootfs_pkgs="$PACKAGES"
-if [ "$DEFAULT_PKGS" = 'yes' ]; then
-	rootfs_pkgs="$ALPINE_BASE_PKGS $rootfs_pkgs"
-fi
-[ "$rootfs_pkgs" ] || die 'No packages specified to be installed!'
+[ "$PACKAGES" ] || [ "$DEFAULT_PKGS" = 'yes' ] || \
+	die 'No packages specified to be installed!'
 
 rootfs="$ROOTFS_DEST"
 if [ "$ROOTFS_DEST" = '-' ]; then
@@ -384,7 +381,10 @@ else
 	dump_alpine_keys "$rootfs"/etc/apk/keys/
 fi
 
-_apk add --root "$rootfs" --update-cache --initdb $rootfs_pkgs >&2
+if [ "$DEFAULT_PKGS" = 'yes' ]; then
+	_apk add --root "$rootfs" --initdb $ALPINE_BASE_PKGS >&2
+fi
+_apk add --root "$rootfs" --initdb $PACKAGES >&2
 
 if ! [ -f "$rootfs"/etc/alpine-release ]; then
 	if _apk info --root "$rootfs" --quiet alpine-release >/dev/null; then


### PR DESCRIPTION
When a package has a pre-install script that adds users, the pre-install actually requires alpine-baselayout-data/busybox to successfully work, but this dependency isn't written anywhere.

After bringing this up on IRC rather than adding the dependency everywhere it was decided to make sure alpine-baselayout is installed first instead, so do this.

--initdb can be used multiple times with no ill side effects, but --updatedb is annoying and not actually useful (will automatically refresh every 4 hours, but starting from an empty directory it'll always fetch it anyway), so just remove it.

--------

This fixes missing users on our systems because some package get installed too early